### PR TITLE
fix breeze:install command in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require laravel/breeze --dev
 
 # after finish run this command
 
-php artisan breeze:install blade
+php artisan breeze:install
 ```
 
 3. Install kamona/kui-laravel-breeze


### PR DESCRIPTION
this fix is to remove the option "blade" from the "php artisan breeze:install blade" command in README file because it's not mentioned in the official Laravel docs ( blade scaffolding is the default option unless you choose vue or react ) so it maybe confusing to some people 

Note : whatever you write after "php artisan breeze:install" like "php artisan breeze:install blah" it will work and install blade views so "blade" is not really an option